### PR TITLE
Optimize patchWindow injection on Chromium

### DIFF
--- a/lib/browser-polyfill.js
+++ b/lib/browser-polyfill.js
@@ -1274,3 +1274,5 @@
     module.exports = browser;
   }
 });
+
+var browser_polyfill_used = true;

--- a/service/DocStartInjection.js
+++ b/service/DocStartInjection.js
@@ -69,7 +69,10 @@ var DocStartInjection = (() => {
 
     if (repeating) {
       let scriptsBlock = [...scripts].join("\n");
-      let injectionId = `injection:${uuid()}:${sha256(scriptsBlock)}`;
+      const scriptBytes = new TextEncoder().encode(scriptsBlock);
+      const hashBytes = await crypto.subtle.digest("SHA-256", scriptBytes);
+      const hash = new Uint8Array(hashBytes).reduce((s, b) => s + b.toString(16).padStart(2, "0"), "");
+      let injectionId = `injection:${uuid()}:${hash}`;
       let args = {
         code: `(() => {
           let injectionId = ${JSON.stringify(injectionId)};


### PR DESCRIPTION
Hello, I am currently working on optimizing JShelter's performance as part of my final thesis and noticed a possible optimization for Chromium injection.

The patchingCallback code is inserted as a string into the page on Chromium, but directly called as a function on Firefox. Currently, a function is constructed from the code at the beginning of patchWindow, however, this is unnecessary on Chromium as the function will never be called, but converted back into a string. Replacing the function constructor with wrapping the code with the correct signature in string form accomplishes the same task, only much faster.

From my measurements, the function constructor call needlessly spends around 20ms parsing code generated by JShelter's "Recommended" level with FPD enabled (~560kB) on every frame load, so this is a nice speedup.